### PR TITLE
Add Terraform module for small EKS cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ By default the example creates a small, highly-available cluster that uses the f
 - EKS control plane running Kubernetes `1.29`
 - Managed node group using on-demand `t3.small` instances (1–3 nodes, desired size 2)
 
+The module automatically tags the subnets so that AWS load balancers created by Kubernetes can be provisioned successfully, and it gracefully limits the requested availability zones to those offered in the selected region.
+
 Refer to the variables defined in `modules/eks-cluster/variables.tf` to customize the deployment.
 
 ## Cleanup

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-test
+# Small EKS Cluster Terraform Module
+
+This repository contains a reusable Terraform module that provisions a minimal Amazon Elastic Kubernetes Service (EKS) cluster along with the networking and IAM dependencies required to get started quickly.
+
+## Module structure
+
+```
+modules/
+└── eks-cluster/
+    ├── main.tf         # Infrastructure definition
+    ├── outputs.tf      # Values exported by the module
+    ├── variables.tf    # Inputs accepted by the module
+    └── versions.tf     # Terraform and provider requirements
+examples/
+└── basic/
+    └── main.tf         # Example instantiation of the module
+```
+
+## Usage
+
+An example configuration is provided under `examples/basic`. Configure your AWS credentials and initialize Terraform:
+
+```sh
+cd examples/basic
+terraform init
+terraform apply
+```
+
+By default the example creates a small, highly-available cluster that uses the following settings:
+
+- Two availability zones with public subnets and internet access
+- EKS control plane running Kubernetes `1.29`
+- Managed node group using on-demand `t3.small` instances (1–3 nodes, desired size 2)
+
+Refer to the variables defined in `modules/eks-cluster/variables.tf` to customize the deployment.
+
+## Cleanup
+
+When finished, destroy the example stack to avoid incurring charges:
+
+```sh
+terraform destroy
+```
+
+Ensure that all dependent resources (such as load balancers or volumes) are deleted before running the destroy command.

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "eks" {
+  source = "../../modules/eks-cluster"
+
+  cluster_name = var.cluster_name
+
+  tags = {
+    Environment = "demo"
+    Project     = "eks-starter"
+  }
+}

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -1,0 +1,14 @@
+output "cluster_name" {
+  value       = module.eks.cluster_name
+  description = "Name of the created EKS cluster."
+}
+
+output "cluster_endpoint" {
+  value       = module.eks.cluster_endpoint
+  description = "Endpoint used to interact with the EKS control plane."
+}
+
+output "node_group_name" {
+  value       = module.eks.node_group_name
+  description = "Managed node group created for the cluster."
+}

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -12,3 +12,8 @@ output "node_group_name" {
   value       = module.eks.node_group_name
   description = "Managed node group created for the cluster."
 }
+
+output "availability_zones" {
+  value       = module.eks.availability_zones
+  description = "Availability zones backing the example cluster."
+}

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  description = "AWS region where the EKS cluster will be deployed."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "cluster_name" {
+  description = "Name to assign to the EKS cluster."
+  type        = string
+  default     = "demo-eks"
+}

--- a/modules/eks-cluster/main.tf
+++ b/modules/eks-cluster/main.tf
@@ -1,0 +1,243 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  azs = slice(data.aws_availability_zones.available.names, 0, var.az_count)
+
+  public_subnet_cidrs = [
+    for index in range(var.az_count) : cidrsubnet(var.vpc_cidr_block, 8, index)
+  ]
+
+  tags = merge({
+    "ManagedBy" = "Terraform"
+  }, var.tags)
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr_block
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(local.tags, {
+    Name = "${var.cluster_name}-vpc"
+  })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(local.tags, {
+    Name = "${var.cluster_name}-igw"
+  })
+}
+
+resource "aws_subnet" "public" {
+  for_each = { for idx, az in local.azs : az => idx }
+
+  vpc_id                  = aws_vpc.this.id
+  availability_zone       = each.key
+  cidr_block              = local.public_subnet_cidrs[each.value]
+  map_public_ip_on_launch = true
+
+  tags = merge(local.tags, {
+    Name = "${var.cluster_name}-public-${each.key}"
+  })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(local.tags, {
+    Name = "${var.cluster_name}-public"
+  })
+}
+
+resource "aws_route" "public_internet_access" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table_association" "public" {
+  for_each       = aws_subnet.public
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_security_group" "cluster" {
+  name        = "${var.cluster_name}-cluster"
+  description = "Cluster communication"
+  vpc_id      = aws_vpc.this.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.tags, {
+    Name = "${var.cluster_name}-cluster"
+  })
+}
+
+resource "aws_security_group" "node" {
+  name        = "${var.cluster_name}-node"
+  description = "Worker node communication"
+  vpc_id      = aws_vpc.this.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.tags, {
+    Name = "${var.cluster_name}-node"
+  })
+}
+
+resource "aws_security_group_rule" "cluster_from_node" {
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.cluster.id
+  source_security_group_id = aws_security_group.node.id
+}
+
+resource "aws_security_group_rule" "node_from_cluster" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.node.id
+  source_security_group_id = aws_security_group.cluster.id
+}
+
+resource "aws_security_group_rule" "node_from_self" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  security_group_id = aws_security_group.node.id
+  self              = true
+}
+
+resource "aws_iam_role" "cluster" {
+  name = "${var.cluster_name}-cluster"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "eks.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSClusterPolicy" {
+  role       = aws_iam_role.cluster.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSVPCResourceController" {
+  role       = aws_iam_role.cluster.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
+}
+
+resource "aws_iam_role" "node" {
+  name = "${var.cluster_name}-node"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEKSWorkerNodePolicy" {
+  role       = aws_iam_role.node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEKS_CNI_Policy" {
+  role       = aws_iam_role.node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEC2ContainerRegistryReadOnly" {
+  role       = aws_iam_role.node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_eks_cluster" "this" {
+  name     = var.cluster_name
+  role_arn = aws_iam_role.cluster.arn
+  version  = var.kubernetes_version
+
+  vpc_config {
+    subnet_ids              = [for subnet in aws_subnet.public : subnet.id]
+    security_group_ids      = [aws_security_group.cluster.id]
+    endpoint_private_access = false
+    endpoint_public_access  = true
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy,
+    aws_iam_role_policy_attachment.cluster_AmazonEKSVPCResourceController
+  ]
+
+  tags = merge(local.tags, {
+    Name = var.cluster_name
+  })
+}
+
+resource "aws_eks_node_group" "default" {
+  cluster_name    = aws_eks_cluster.this.name
+  node_group_name = "${var.cluster_name}-default"
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = [for subnet in aws_subnet.public : subnet.id]
+  ami_type        = "AL2_x86_64"
+  capacity_type   = "ON_DEMAND"
+  instance_types  = var.instance_types
+
+  scaling_config {
+    desired_size = var.desired_size
+    max_size     = var.max_size
+    min_size     = var.min_size
+  }
+
+  update_config {
+    max_unavailable = 1
+  }
+
+  remote_access {
+    ec2_ssh_key               = null
+    source_security_group_ids = []
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node_AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.node_AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly
+  ]
+
+  tags = merge(local.tags, {
+    Name = "${var.cluster_name}-default"
+  })
+}

--- a/modules/eks-cluster/main.tf
+++ b/modules/eks-cluster/main.tf
@@ -3,11 +3,15 @@ data "aws_availability_zones" "available" {
 }
 
 locals {
-  azs = slice(data.aws_availability_zones.available.names, 0, var.az_count)
+  available_azs     = data.aws_availability_zones.available.names
+  selected_az_count = min(var.az_count, length(local.available_azs))
+  azs               = slice(local.available_azs, 0, local.selected_az_count)
 
   public_subnet_cidrs = [
-    for index in range(var.az_count) : cidrsubnet(var.vpc_cidr_block, 8, index)
+    for index in range(local.selected_az_count) : cidrsubnet(var.vpc_cidr_block, 8, index)
   ]
+
+  cluster_tag_key = "kubernetes.io/cluster/${var.cluster_name}"
 
   tags = merge({
     "ManagedBy" = "Terraform"
@@ -40,9 +44,17 @@ resource "aws_subnet" "public" {
   cidr_block              = local.public_subnet_cidrs[each.value]
   map_public_ip_on_launch = true
 
-  tags = merge(local.tags, {
-    Name = "${var.cluster_name}-public-${each.key}"
-  })
+  tags = merge(
+    local.tags,
+    {
+      Name                               = "${var.cluster_name}-public-${each.key}"
+      "kubernetes.io/role/elb"           = "1"
+      "kubernetes.io/role/internal-elb"  = "0"
+    },
+    {
+      (local.cluster_tag_key) = "shared"
+    }
+  )
 }
 
 resource "aws_route_table" "public" {
@@ -224,11 +236,6 @@ resource "aws_eks_node_group" "default" {
 
   update_config {
     max_unavailable = 1
-  }
-
-  remote_access {
-    ec2_ssh_key               = null
-    source_security_group_ids = []
   }
 
   depends_on = [

--- a/modules/eks-cluster/outputs.tf
+++ b/modules/eks-cluster/outputs.tf
@@ -1,0 +1,34 @@
+output "cluster_name" {
+  description = "Name of the EKS cluster."
+  value       = aws_eks_cluster.this.name
+}
+
+output "cluster_endpoint" {
+  description = "API server endpoint for the EKS cluster."
+  value       = aws_eks_cluster.this.endpoint
+}
+
+output "cluster_security_group_id" {
+  description = "Security group ID used by the control plane."
+  value       = aws_security_group.cluster.id
+}
+
+output "node_security_group_id" {
+  description = "Security group ID used by the worker nodes."
+  value       = aws_security_group.node.id
+}
+
+output "vpc_id" {
+  description = "ID of the VPC that hosts the cluster."
+  value       = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets hosting the worker nodes."
+  value       = [for subnet in aws_subnet.public : subnet.id]
+}
+
+output "node_group_name" {
+  description = "Name of the managed node group."
+  value       = aws_eks_node_group.default.node_group_name
+}

--- a/modules/eks-cluster/outputs.tf
+++ b/modules/eks-cluster/outputs.tf
@@ -32,3 +32,8 @@ output "node_group_name" {
   description = "Name of the managed node group."
   value       = aws_eks_node_group.default.node_group_name
 }
+
+output "availability_zones" {
+  description = "Availability zones used for the cluster subnets."
+  value       = local.azs
+}

--- a/modules/eks-cluster/variables.tf
+++ b/modules/eks-cluster/variables.tf
@@ -1,0 +1,52 @@
+variable "cluster_name" {
+  description = "Name of the EKS cluster."
+  type        = string
+}
+
+variable "vpc_cidr_block" {
+  description = "CIDR block for the VPC that will host the cluster."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "az_count" {
+  description = "Number of availability zones to spread the cluster across."
+  type        = number
+  default     = 2
+}
+
+variable "kubernetes_version" {
+  description = "Desired Kubernetes version for the control plane."
+  type        = string
+  default     = "1.29"
+}
+
+variable "desired_size" {
+  description = "Desired number of worker nodes."
+  type        = number
+  default     = 2
+}
+
+variable "min_size" {
+  description = "Minimum number of worker nodes."
+  type        = number
+  default     = 1
+}
+
+variable "max_size" {
+  description = "Maximum number of worker nodes."
+  type        = number
+  default     = 3
+}
+
+variable "instance_types" {
+  description = "List of EC2 instance types for the managed node group."
+  type        = list(string)
+  default     = ["t3.small"]
+}
+
+variable "tags" {
+  description = "A map of tags to apply to all taggable resources."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/eks-cluster/variables.tf
+++ b/modules/eks-cluster/variables.tf
@@ -13,6 +13,11 @@ variable "az_count" {
   description = "Number of availability zones to spread the cluster across."
   type        = number
   default     = 2
+
+  validation {
+    condition     = var.az_count >= 1
+    error_message = "az_count must be at least 1."
+  }
 }
 
 variable "kubernetes_version" {

--- a/modules/eks-cluster/versions.tf
+++ b/modules/eks-cluster/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable Terraform module that provisions networking, IAM roles, an EKS cluster, and a managed node group
- provide module inputs, outputs, and provider requirements
- document the repository layout and usage along with an example configuration

## Testing
- terraform fmt -recursive *(fails: terraform not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4de3ac01483328b417348a0186d2e